### PR TITLE
Fix migration error by adding description column and user isolation mode setting

### DIFF
--- a/database/migrations/018_add_user_isolation.sql
+++ b/database/migrations/018_add_user_isolation.sql
@@ -30,6 +30,11 @@ FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL;
 ALTER TABLE notification_groups 
 ADD INDEX idx_notification_groups_user_id (user_id);
 
+-- Add an optional 'description' column to the settings table
+-- This column stores a human-readable explanation of each setting,
+-- used in newer versions for improved configuration clarity.
+ALTER TABLE settings ADD COLUMN description TEXT NULL AFTER setting_value;
+
 -- Add user isolation mode setting
 INSERT INTO settings (setting_key, setting_value, description) VALUES 
 ('user_isolation_mode', 'shared', 'User data visibility mode: shared (all users see all data) or isolated (users see only their own data)')


### PR DESCRIPTION
Added a 'description' column to the settings table for improved clarity and inserted a new user isolation mode setting.

## Description
Fixed the migration error caused by the missing `description` column in the `settings` table. This column is required for inserting the `user_isolation_mode` setting.  

The column was added and the setting inserted to ensure future updates run correctly.

## Type of Change
- [x] Bug fix (non-breaking change)

## Testing
- Ran migration successfully
- Verified `description` column exists
- Verified `user_isolation_mode` setting inserted

## Breaking Changes
None
